### PR TITLE
Add means of fetching start & end colors

### DIFF
--- a/Scripts/VRLineRenderer.cs
+++ b/Scripts/VRLineRenderer.cs
@@ -53,6 +53,11 @@ public class VRLineRenderer : MonoBehaviour
     public float widthEnd { get { return m_WidthEnd; } }
 
     /// <summary>
+    /// Return an array whose constituents are the start and end colors, in that order
+    /// </summary>
+    public Color[] colors { get { return new[]{m_ColorStart, m_ColorEnd}; } }
+
+    /// <summary>
     /// Ensures the lines have all their data precached upon loading
     /// </summary>
     void Awake()

--- a/Scripts/VRLineRenderer.cs
+++ b/Scripts/VRLineRenderer.cs
@@ -51,11 +51,8 @@ public class VRLineRenderer : MonoBehaviour
 
     public float widthStart { get { return m_WidthStart; } }
     public float widthEnd { get { return m_WidthEnd; } }
-
-    /// <summary>
-    /// Return an array whose constituents are the start and end colors, in that order
-    /// </summary>
-    public Color[] colors { get { return new[]{m_ColorStart, m_ColorEnd}; } }
+    public Color colorStart { get { return m_ColorStart; } }
+    public Color colorEnd { get { return m_ColorEnd; } }
 
     /// <summary>
     /// Ensures the lines have all their data precached upon loading


### PR DESCRIPTION
**Purpose of this PR**

Add a property that allows for external fetching of the start & end color.  External control of start/end color lerping is being done in EditorVR, specifically the ToolFlow branch(es).  There are cases in which there is the need to animate these values via a 0-1 lerp.  At the beginning of this lerp, the current start & end color are necessary.

**Testing status**

I've run into no issues with this implementation in my many tests thus far.

**Technical risk**

Low: It's an addition of a get-only property that returns an array of colors(structs).  So imho not much/any technical risk

**Comments to reviewers**

I see potential inconsistency in the implementation of return value functionality in VRLineRenderer.  Some values are returned via a function call, whose structure could basically be a property.  In addition, there are also properties that serve the same purpose (widthStart, widthEnd).  Perhaps these simple return value implementation could be unified into just properties (or functions if the branch owner prefers).