### PR TITLE
Improving a scenario for importing older implementations of the line renderer

### DIFF
--- a/Scripts/MeshChainRenderer.cs
+++ b/Scripts/MeshChainRenderer.cs
@@ -245,7 +245,7 @@ public abstract class MeshChainRenderer : MonoBehaviour
         var meshFilter = GetComponent<MeshFilter>();
         meshFilter.hideFlags = HideFlags.HideInInspector;
 
-        if (m_Materials == null)
+        if (m_Materials == null || m_Materials.Length == 0)
         {
             m_Materials = m_MeshRenderer.sharedMaterials;
         }


### PR DESCRIPTION
### Purpose of this PR
When updating the XRFT to use the new line renderer, I noticed a few objects were not matching their materials up between the hidden meshrenderer and line renderer component, this fixes that
### Testing status

Manual testing in the UIInteractionTest scene in the XRFT

### Technical risk

Extremely low - a one line change that changes from a null check to a null-or-empty check

### Comments to reviewers
