### PR TITLE
add public loop bool to XRLineRenderer

### DIFF
--- a/Scripts/XRLineRenderer.cs
+++ b/Scripts/XRLineRenderer.cs
@@ -29,7 +29,12 @@ public class XRLineRenderer : MeshChainRenderer
     public bool loop
     {
         get { return m_Loop; }
-        set { m_Loop = value; }
+        set
+        {
+            m_Loop = value;
+            if (NeedsReinitialize())
+                Initialize();
+        }
     }
 
     /// <summary>

--- a/Scripts/XRLineRenderer.cs
+++ b/Scripts/XRLineRenderer.cs
@@ -25,7 +25,13 @@ public class XRLineRenderer : MeshChainRenderer
     [SerializeField]
     [Tooltip("Connect the first and last vertices, to create a loop.")]
     bool m_Loop;
-    
+
+    public bool loop
+    {
+        get { return m_Loop; }
+        set { m_Loop = value; }
+    }
+
     /// <summary>
     /// Draw lines in worldspace (or local space)
     /// </summary>


### PR DESCRIPTION
This is a change i made to the line renderer for use in a project of mine, where i'm visualizing mobile AR data in the Editor (https://github.com/stella3d/Point-Cloud-Recorder/tree/master/Assets/XRLineRenderer/Scripts)

here's how i'm using it:

1) I instantiate a number of `XRLineRenderer`s in an array from a script
2) then use them to draw bounds polygons for each of the tracked planes.  

without a way to set it to `loop` from a script, i can't use the line renderer to draw closed polygons for this use case where i can't set it in the inspector.  Once i can do that, it's very useful!